### PR TITLE
Added nullability annotations and list typing

### DIFF
--- a/LMGeocoder/LMAddress.h
+++ b/LMGeocoder/LMAddress.h
@@ -23,47 +23,47 @@
 /*!
  *  The precise street address.
  */
-@property (nonatomic, readonly, copy) NSString *thoroughfare;
+@property (nonatomic, readonly, copy, nullable) NSString *thoroughfare;
 
 /*!
  *  The incorporated city or town political entity.
  */
-@property (nonatomic, readonly, copy) NSString *locality;
+@property (nonatomic, readonly, copy, nullable) NSString *locality;
 
 /*!
  *  The first-order civil entity below a localit.
  */
-@property (nonatomic, readonly, copy) NSString *subLocality;
+@property (nonatomic, readonly, copy, nullable) NSString *subLocality;
 
 /*!
  *  The civil entity below the country level.
  */
-@property (nonatomic, readonly, copy) NSString *administrativeArea;
+@property (nonatomic, readonly, copy, nullable) NSString *administrativeArea;
 
 /*!
  *  The Postal/Zip code.
  */
-@property (nonatomic, readonly, copy) NSString *postalCode;
+@property (nonatomic, readonly, copy, nullable) NSString *postalCode;
 
 /*!
  *  The country name.
  */
-@property (nonatomic, readonly, copy) NSString *country;
+@property (nonatomic, readonly, copy, nullable) NSString *country;
 
 /*!
  *  The ISO country code.
  */
-@property (nonatomic, readonly, copy) NSString *ISOcountryCode;
+@property (nonatomic, readonly, copy, nullable) NSString *ISOcountryCode;
 
 /*!
  *  The formatted address.
  */
-@property (nonatomic, readonly, copy) NSString *formattedAddress;
+@property (nonatomic, readonly, copy, nullable) NSString *formattedAddress;
 
 /*!
  *  An array of NSString containing formatted lines of the address.
  */
-@property(nonatomic, readonly, copy) NSArray *lines;
+@property(nonatomic, readonly, copy, nullable) NSArray<NSString *> *lines;
 
 /*!
  *  Initialize with response from server
@@ -73,6 +73,6 @@
  *
  *  @return object with all data set for use
  */
-- (id)initWithLocationData:(id)locationData forServiceType:(int)serviceType;
+- (nonnull id)initWithLocationData:(nonnull id)locationData forServiceType:(int)serviceType;
 
 @end

--- a/LMGeocoder/LMGeocoder.h
+++ b/LMGeocoder/LMGeocoder.h
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSInteger, LMGeocoderErrorCode){
 /*!
  *  Handler that reports a geocoding response, or error.
  */
-typedef void (^LMGeocodeCallback) (NSArray *results, NSError *error);
+typedef void (^LMGeocodeCallback) (NSArray<LMAddress *> * _Nullable results,  NSError * _Nullable error);
 
 /*!
  *  Exposes a service for geocoding and reverse geocoding.
@@ -45,17 +45,17 @@ typedef void (^LMGeocodeCallback) (NSArray *results, NSError *error);
 /*!
  *  To set google API key
  */
-@property (nonatomic, strong) NSString *googleAPIKey;
+@property (nonatomic, strong, nullable) NSString *googleAPIKey;
 
 /*!
  *  Get shared instance.
  */
-+ (LMGeocoder *)sharedInstance;
++ (nonnull LMGeocoder *)sharedInstance;
 
 /*!
  *  Convenience constructor for LMGeocoder.
  */
-+ (LMGeocoder *)geocoder;
++ (nonnull LMGeocoder *)geocoder;
 
 /*!
  *  Submits a forward-geocoding request using the specified string.
@@ -67,9 +67,9 @@ typedef void (^LMGeocodeCallback) (NSArray *results, NSError *error);
  *  @param service       The service API used to geocode.
  *  @param handler       The callback to invoke with the geocode results. The callback will be invoked asynchronously from the main thread.
  */
-- (void)geocodeAddressString:(NSString *)addressString
+- (void)geocodeAddressString:(nonnull NSString *)addressString
                      service:(LMGeocoderService)service
-           completionHandler:(LMGeocodeCallback)handler;
+           completionHandler:(nonnull LMGeocodeCallback)handler;
 
 /*!
  *  Submits a reverse-geocoding request for the specified coordinate.
@@ -83,7 +83,7 @@ typedef void (^LMGeocodeCallback) (NSArray *results, NSError *error);
  */
 - (void)reverseGeocodeCoordinate:(CLLocationCoordinate2D)coordinate
                          service:(LMGeocoderService)service
-               completionHandler:(LMGeocodeCallback)handler;
+               completionHandler:(nonnull LMGeocodeCallback)handler;
 
 /*!
  *  Cancels a pending geocoding request.


### PR DESCRIPTION
Added typing and nullabilities for Swift use. I've marked a few parameters nonnull where sending a null parameter just results in a no-op. I also assume [NSObject init] cannot fail.
